### PR TITLE
added uri encoding to email

### DIFF
--- a/sendinblue-api.js
+++ b/sendinblue-api.js
@@ -850,7 +850,7 @@ SendinblueAPI.prototype.get_user = function(data, cb) {
 	var email = data.email;
 
 	delete data.email;
-	this.get_request('user/' + email, '', function(error, result) {
+	this.get_request('user/' + encodeURIComponent(email), '', function(error, result) {
 		if (error) {
 			return cb(error, null);
 		}


### PR DESCRIPTION
Hi! There is issue when using get_user method, as when you provide little bit untypical email address (like zażółć@example.com) it will fail, as diacritics won't pass properly through sendinblue api, and server will return 400 error.

It solved issue for me, so I thought I'll share.